### PR TITLE
add `--check-creds` flag to `fly` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@ fly:
   target: myFlyTarget
   config: pipeline.yml
   non_interactive: true
+  check_creds: true
   load_vars_from:
   - credentials.yml
   vars:

--- a/executor/flyexecutor.go
+++ b/executor/flyexecutor.go
@@ -25,6 +25,7 @@ const (
 	loadVarsFromFlag   = "--load-vars-from"
 	varFlag            = "--var"
 	nonInteractiveFlag = "--non-interactive"
+	checkCredsFlag     = "--check-creds"
 )
 
 type FlyExecutor struct{}
@@ -65,6 +66,10 @@ func (e FlyExecutor) Command(cfg interface{}) ([]*exec.Cmd, error) {
 
 		if fly.NonInteractive {
 			args = append(args, nonInteractiveFlag)
+		}
+
+		if fly.CheckCreds {
+			args = append(args, checkCredsFlag)
 		}
 	}
 

--- a/models.go
+++ b/models.go
@@ -61,6 +61,7 @@ type Fly struct {
 	Expose         bool              `yaml:"expose"`
 	Var            map[string]string `yaml:"vars"`
 	NonInteractive bool              `yaml:"non_interactive"`
+	CheckCreds     bool              `yaml:"check_creds"`
 
 	//Validate Pipeline
 	ValidatePipeline bool `yaml:"validate_pipeline"`


### PR DESCRIPTION
Add additional option to Aviator to allow setting the [fly set-pipeline](https://concourse-ci.org/setting-pipelines.html#pipeline-static-vars) commands `--check-creds` flag, which validates variables against Concourse's secrets engine.

Signed-off-by: Daniel Hill <dan@mamu.co>